### PR TITLE
Add atomicity and locking to object actions.

### DIFF
--- a/daf/tests/actions/__init__.py
+++ b/daf/tests/actions/__init__.py
@@ -1,3 +1,4 @@
+from .atomic import AtomicCheck
 from .basic import Basic
 from .bulk_grant_staff_access import BulkGrantStaffAccess
 from .grant_staff_access import GrantStaffAccess
@@ -5,6 +6,7 @@ from .update_my_field import UpdateMyField
 from .update_my_model import UpdateMyModel
 
 __all__ = [
+    'AtomicCheck',
     'Basic',
     'GrantStaffAccess',
     'BulkGrantStaffAccess',

--- a/daf/tests/actions/atomic.py
+++ b/daf/tests/actions/atomic.py
@@ -1,0 +1,41 @@
+"""For integration tests of atomicity"""
+from django import forms
+import django.contrib.auth.models as auth_models
+
+import daf.actions
+import daf.rest_framework
+import daf.views
+
+
+def atomic_check(user, username, first_name):
+    """
+    For verifying atomicity of actions
+    """
+    user.first_name = first_name
+    user.save()
+    user.username = username
+    user.save()
+
+
+class AtomicCheck(daf.actions.ObjectAction):
+    """
+    Updates first_name and a field with a unique constraint to test atomicity
+    """
+
+    app_label = 'tests'
+    name = 'atomic_check'
+    callable = atomic_check
+    model = auth_models.User
+    object_arg = 'user'
+
+
+class AtomicCheckObjectForm(forms.Form):
+    username = forms.CharField()
+    first_name = forms.CharField()
+
+
+class AtomicCheckObjectFormView(daf.views.ObjectFormView):
+    action = AtomicCheck
+    form_class = AtomicCheckObjectForm
+    success_url = '.'
+    template_name = 'tests/action.html'

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -682,3 +682,22 @@ non-rest framework errors with the stringified error as the message.
 However, if a Django ``ValidationError`` is raised,
 `daf.rest_framework.raise_drf_error` will fill in the ``code`` of the
 ``APIException`` using the ``code`` from the ``ValidationError``.
+
+
+Atomicity of actions
+--------------------
+
+All action classes that operate on objects (`daf.actions.ObjectAction` and
+`daf.actions.ObjectsAction`) operate atomically by default, meaning that
+a ``select_for_update`` is applied to the object(s) in question in a transaction
+before running any validations or action code. If this behavior is
+undesirable or if the user wishes to control atomicity manually, set
+the ``select_for_update`` class variable on the action class to ``None``.
+
+.. note::
+
+    The ``select_for_update`` class attribute just passes the argument through
+    to ``djarg.qset``. For more information about how to configure this
+    parameter to suit your needs (such as skipping locked objects),
+    see the `djarg docs <https://django-args.readthedocs.io>`__ and
+    the `docs for select_for_update <https://docs.djangoproject.com/en/3.0/ref/models/querysets/#select-for-update>`__.

--- a/poetry.lock
+++ b/poetry.lock
@@ -237,7 +237,7 @@ description = "Distribution utilities"
 name = "distlib"
 optional = false
 python-versions = "*"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 category = "dev"
@@ -270,12 +270,12 @@ description = "Django wrappers for python-args functions."
 name = "django-args"
 optional = false
 python-versions = ">=3.6,<4"
-version = "1.0.0"
+version = "1.1.0"
 
 [package.dependencies]
 django = ">=2"
 django-formtools = ">=2.2,<3.0"
-python-args = ">=1.0.0,<2.0.0"
+python-args = ">=1.0.2,<2.0.0"
 
 [[package]]
 category = "dev"
@@ -430,7 +430,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9"
+version = "2.10"
 
 [[package]]
 category = "dev"
@@ -446,7 +446,7 @@ description = "Read metadata from Python packages"
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.1"
+version = "1.7.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -745,7 +745,7 @@ description = "Python argument design patterns in a composable interface."
 name = "python-args"
 optional = false
 python-versions = ">=3.6,<4"
-version = "1.0.0"
+version = "1.0.2"
 
 [[package]]
 category = "dev"
@@ -1115,7 +1115,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "bdcc7733c51491efef6eb01c9d6cef9d6e825a345f31a72bc112fa867085b457"
+content-hash = "5006f7b2a166ad5b69ceb8069614e63d156b0523528bd7153d5fecde07febc2e"
 python-versions = ">=3.6,<4"
 
 [metadata.files]
@@ -1230,7 +1230,8 @@ coverage = [
     {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 distlib = [
-    {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
+    {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
+    {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
 ]
 dj-database-url = [
     {file = "dj-database-url-0.5.0.tar.gz", hash = "sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163"},
@@ -1241,8 +1242,8 @@ django = [
     {file = "Django-3.0.7.tar.gz", hash = "sha256:5052b34b34b3425233c682e0e11d658fd6efd587d11335a0203d827224ada8f2"},
 ]
 django-args = [
-    {file = "django-args-1.0.0.tar.gz", hash = "sha256:6d7291e57c3f47e332c8234fb2e222f8542a257ab7b574332df9dca724a2080f"},
-    {file = "django_args-1.0.0-py3-none-any.whl", hash = "sha256:c26706f36f9d800150ebd12713aa112e6d3f5027109430daf68023d7936a426a"},
+    {file = "django-args-1.1.0.tar.gz", hash = "sha256:4f6cead51fe45125296cd3580775f657e06dccd3631fe3fc594a48861ae962fb"},
+    {file = "django_args-1.1.0-py3-none-any.whl", hash = "sha256:120f2c4d4e918cca455302fb10eb0d9f36844a3113ed1989dd4bdcea312316c1"},
 ]
 django-dynamic-fixture = [
     {file = "django-dynamic-fixture-3.1.0.tar.gz", hash = "sha256:e772102ba40f70c2e66470cae85f3874aa992e6b22a0d0c360450f2949b0728d"},
@@ -1300,16 +1301,16 @@ identify = [
     {file = "identify-1.4.20.tar.gz", hash = "sha256:b2cd24dece806707e0b50517c1b3bcf3044e0b1cb13a72e7d34aa31c91f2a55a"},
 ]
 idna = [
-    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
-    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 imagesize = [
     {file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1"},
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.6.1-py2.py3-none-any.whl", hash = "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"},
-    {file = "importlib_metadata-1.6.1.tar.gz", hash = "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545"},
+    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
+    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
 ]
 importlib-resources = [
     {file = "importlib_resources-2.0.1-py2.py3-none-any.whl", hash = "sha256:83985739b3a6679702f9ab33f0ad016ad564664d0568a31ac14d7c64789453e6"},
@@ -1461,8 +1462,8 @@ pytest-mock = [
     {file = "pytest_mock-2.0.0-py2.py3-none-any.whl", hash = "sha256:cb67402d87d5f53c579263d37971a164743dc33c159dfb4fb4a86f37c5552307"},
 ]
 python-args = [
-    {file = "python-args-1.0.0.tar.gz", hash = "sha256:35b57e8086d0ab879f02923fb0ab4c620af70ccc0c2470d64c32b2936897adae"},
-    {file = "python_args-1.0.0-py3-none-any.whl", hash = "sha256:6f28b8577c90e8ba26bdfa4efac48b7fed92d38d6f6043c6559ec52ae6d1fc72"},
+    {file = "python-args-1.0.2.tar.gz", hash = "sha256:414ff6f74f42fdfbc279587b8394f89331a6d9db22c890e3fb8be4dc45e8ff49"},
+    {file = "python_args-1.0.2-py3-none-any.whl", hash = "sha256:fe96c87aa9622a33d058821a9cd96fc61489bdad743cfcc0b729e1db951f9698"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ documentation = "https://django-action-framework.readthedocs.io"
 python = ">=3.6,<4"
 django = ">=2"
 djangorestframework = "^3.0.0"
-python-args = "^1.0.0"
-django-args = "^1.0.0"
+python-args = "^1.0.2"
+django-args = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 beautifulsoup4 = "^4.8.2"


### PR DESCRIPTION
By default, ``ObjectAction`` and ``ObjectsAction`` lock the object(s)
being updated with a select_for_update and wrap the action in a transaction.
Since this is done with the ``djarg.qset`` helper, transactions and locking
will *not* happen when only running validations.

This behavior was documented and can be turned off by setting the
``select_for_update`` attribute of actions to ``None``

Type: feature