### PR TITLE
Avoid using Django settings in module top-level

### DIFF
--- a/daf/rest_framework.py
+++ b/daf/rest_framework.py
@@ -47,11 +47,14 @@ class APIException(drf_exceptions.APIException):
     The base error class raised by `raise_drf_error`.
     """
 
-    status_code = getattr(
-        settings,
-        'DAF_DEFAULT_REST_FRAMEWORK_ERROR_STATUS_CODE',
-        drf_status.HTTP_400_BAD_REQUEST,
-    )
+    @property
+    def status_code(self):
+        return getattr(
+            settings,
+            'DAF_DEFAULT_REST_FRAMEWORK_ERROR_STATUS_CODE',
+            drf_status.HTTP_400_BAD_REQUEST,
+        )
+
     default_detail = 'Invalid input.'
     default_code = 'invalid'
 


### PR DESCRIPTION
Moving usage of Django settings from module top-level to a property, since it can break things if `daf.rest_framework` is imported too "early" on when a Django process starts up, if the settings have not been loaded up properly by Django.

Fixes this issue: #3 