### PR TITLE
Improve sensitive imports

### DIFF
--- a/daf/rest_framework.py
+++ b/daf/rest_framework.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 import rest_framework.status as drf_status
 
 import daf.interfaces
+import daf.registry
 
 
 class InstallDAFActions(type):

--- a/daf/rest_framework.py
+++ b/daf/rest_framework.py
@@ -6,7 +6,6 @@ from django import forms
 from django.conf import settings
 from django.core import exceptions
 import djarg.forms
-import rest_framework.decorators as drf_decorators
 import rest_framework.exceptions as drf_exceptions
 from rest_framework.response import Response
 import rest_framework.status as drf_status
@@ -182,6 +181,14 @@ class DetailAction(daf.interfaces.Interface):
             **kwargs: Any additional argument accepted by the drf.action
                 decorator.
         """
+        # NOTE(@tomage): Moving this import in here, as if it is on module top-
+        # level, it results in an error if `daf.rest_framework` is imported
+        # prematurely in another process (e.g. before Django has loaded up the
+        # settings module).
+        # It is generally discouraged that libraries do this (see django docs)
+        # and this issue has been reported to DRF in particular (see
+        # here: https://github.com/encode/django-rest-framework/issues/6030).
+        import rest_framework.decorators as drf_decorators
 
         def _drf_detail_action(viewset, request, pk, **kwargs):
             """


### PR DESCRIPTION
This is a follow-up to https://github.com/jyveapp/django-action-framework/pull/4.

Turns out, DRF uses Django settings "prematurely" quite a bit in many different modules, which is [discouraged by Django](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#use-of-django-conf-settings).

There's been several issues reported where DRF "breaks" Django's recommendation on this topic (here's one: https://github.com/encode/django-rest-framework/issues/6030), but it'll take some time before they fix all these cases.

The `daf.rest_framework` module imports one of these modules in top-level, resulting in premature usage of Django settings if one were to import `daf.rest_framework` directly before Django settings were loaded up.

I know this may really just seem like a trivial thing - but until DRF fixes more of it's problems, I figured it'd be good to tackle it here.

As it happens - doing this allowed me to discover another import issue - namely that `daf.registry` is used in `daf.rest_framework` but is not imported.

Usually this is not a problem as usually some other module from `daf` is loaded up before `daf.rest_framework` that ends up loading up `daf.registry` into the module registry in Python, making `daf.registry` accessible.

This is a pretty interesting, and insidious bug that I haven't come across before. So, out of interest, I replicated it thus:

```bash
$ cat good.py
import mod.foo
mod.foo
mod.bar  # NOTE: no import of mod.bar

$ cat bad.py
import mod.bar
mod.bar
mod.foo  # NOTE: no import of mod.foo

$ cat mod/foo.py
from . import bar

$ cat mod/bar.py
# empty

$ python good.py  # runs just fine

$ python bad.py
<error traceback>
AttributeError: module 'mod' has no attribute 'foo'
```