### PR TITLE
Don't override action methods on viewset classes

### DIFF
--- a/daf/rest_framework.py
+++ b/daf/rest_framework.py
@@ -22,7 +22,8 @@ class InstallDAFActions(type):
 
         for interface in cls.get_daf_actions().filter(type='detail_action'):
             method_name = f'detail_{interface.action.name}'
-            setattr(cls, method_name, interface.as_interface())
+            if not hasattr(cls, method_name):  # pragma: no cover
+                setattr(cls, method_name, interface.as_interface())
 
         return cls
 


### PR DESCRIPTION
When DAF overrides the class definition with actions, it now will check
if the action is already defined and ignore setting the class attribute.
Previously it asserted it wasn't there and failed loudly, but that caused
issues for subclasses. Overriding it also causes issues for subclasses.

For now, we are ignoring adding the action if it is already defined.
We may want to revisit this behavior in the future.

Type: bug